### PR TITLE
Add rule for single staging model per source

### DIFF
--- a/olivertwist/rules/source_has_single_staging.py
+++ b/olivertwist/rules/source_has_single_staging.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Sources should have a single staging model.
+
+"""
+
+from typing import List, Tuple
+
+from olivertwist.manifest import Manifest, Node
+from olivertwist.ruleengine.rule import rule
+from olivertwist.rules.utils import partition
+
+
+@rule(
+    id="single-staging-model-per-source",
+    name="Sources can only reference a single staging script",
+)
+def sources_have_single_staging_model(
+    manifest: Manifest,
+) -> Tuple[List[Node], List[Node]]:
+    def source_has_more_than_one_staging_model(node: Node):
+        stages = [
+            p
+            for p in manifest.graph.predecessors(node.id)
+            if manifest.get_node(p).is_staging
+        ]
+        return node.is_source and len(list(stages)) > 1
+
+    passes, failures = partition(
+        source_has_more_than_one_staging_model, manifest.nodes()
+    )
+    return list(passes), list(failures)

--- a/tests/rules/test_source_has_single_staging.py
+++ b/tests/rules/test_source_has_single_staging.py
@@ -1,0 +1,66 @@
+import pytest
+
+from olivertwist.manifest import Manifest
+from olivertwist.rules.source_has_single_staging import (
+    sources_have_single_staging_model,
+)
+
+
+@pytest.fixture
+def manifest() -> Manifest:
+    return Manifest(
+        {
+            "nodes": {
+                "staging.b": {
+                    "unique_id": "staging.b",
+                    "fqn": ["staging", "b"],
+                    "resource_type": "model",
+                },
+                "staging.z": {
+                    "unique_id": "staging.z",
+                    "fqn": ["staging", "z"],
+                    "resource_type": "model",
+                },
+                "staging.y": {
+                    "unique_id": "staging.y",
+                    "fqn": ["staging", "y"],
+                    "resource_type": "model",
+                },
+            },
+            "child_map": {
+                "a": ["staging.b"],
+                "staging.b": [],
+                "x": ["staging.z","staging.y"],
+                "staging.y": [],
+                "staging.z": [],
+            },
+            "disabled": [],
+            "sources": {
+                "a": {
+                    "unique_id": "a",
+                    "fqn": ["a"],
+                    "resource_type": "source",
+                },
+                "x": {
+                    "unique_id": "x",
+                    "fqn": ["x"],
+                    "resource_type": "source",
+                },
+                "y": {
+                    "unique_id": "y",
+                    "fqn": ["y"],
+                    "resource_type": "source",
+                },
+            },
+        }
+    )
+
+
+def test_sources_have_single_staging_model_returns_correct_split(manifest):
+    passes, failures = sources_have_single_staging_model(manifest)
+
+    pass_ids = [p.id for p in passes]
+    failure_ids = [f.id for f in failures]
+
+    assert pass_ids == ["a", "staging.b", "x", "y"]
+    assert failure_ids == ["x"]


### PR DESCRIPTION
Currently validation only works for failing multiple sources per staging model and not vice versa as should be the case. This fixes that so its a two way validation. 